### PR TITLE
Fix Prefix Error in GetRelativePath

### DIFF
--- a/src/LibFileTools.bas
+++ b/src/LibFileTools.bas
@@ -1791,12 +1791,15 @@ Public Function GetRelativePath(ByRef fullPath As String _
     Dim rParent As String
     Dim prevPos As Long
     Dim currPos As Long
+    Dim rcurrPos As Long
     Dim diff As Long
     Dim isRFile As Boolean
     '
     Do
         prevPos = currPos
         currPos = InStr(currPos + 1, fPath, ps)
+        rcurrPos = InStr(prevPos + 1, rPath, ps)
+	    If currPos <> rcurrPos Then Exit Do
         diff = currPos - prevPos - 1
         If diff > 0 Then
             fParent = Mid$(fPath, prevPos + 1, diff)


### PR DESCRIPTION
When the relativeToFullPath contains a Foldername of the fullPath as a Prefix of a folder it will be ignored.
This PR adds a checks if both foldernames have the same length.

**To Reproduce**
```
Private Sub testRel()
  Dim Path1 As String
  Dim Path2 As String
  Dim Path3 As String
  Dim RelPath1 As String
  Dim RelPath2 As String
  
  Path1 = "C:\Testfolder\Work\Test\"
  Path2 = "C:\Testfolder\Done\Test\"
  Path3 = "C:\Testfolder\Work_old\Test\"
  
  RelPath1 = GetRelativePath(Path1, Path2)
  RelPath2 = GetRelativePath(Path1, Path3)
  
  Debug.Print (RelPath1)
  Debug.Print (RelPath2)
End Sub
```

The Output is

```
..\..\Work\Test\
..\..\Test\
```

Expected Output

```
..\..\Work\Test\
..\..\Work\Test\
```